### PR TITLE
Add steps to generate and commit an index.html

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -114,7 +114,11 @@ jobs:
         run: |-
           set -e
           helm repo index --url "${ASSETS_BASE_URL}" .
+          # Install index.html generator
+          helm plugin install https://github.com/halkeye/helm-repo-html
+          helm repo-html
           # FIXME(bandini): this is for debugging only
+          ls -l index.html
           cat index.yaml
 
       - name: Checkout code to git-repo folder
@@ -132,9 +136,9 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git checkout gh-pages
           # This copies the newly generated index.yaml to the git repo
-          cp -fv ../index.yaml .
-          git add index.yaml
-          git commit index.yaml -m "Updated ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}"
+          cp -fv ../index.yaml ../index.html .
+          git add index.yaml index.html
+          git commit -m "Updated ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}"
           git push origin gh-pages
 
       - name: Push the chart to quay

--- a/index.tpl
+++ b/index.tpl
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Helm Charts</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.min.css" />
+    <style>
+      .markdown-body {
+        box-sizing: border-box;
+        min-width: 200px;
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 45px;
+      }
+      @media (max-width: 767px) {
+        .markdown-body {
+          padding: 15px;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <section class="markdown-body">
+      <h1>Helm Charts for Validated Patterns</h1>
+
+      <h2>Usage</h2>
+      <pre lang="no-highlight"><code>
+        helm repo add validated-patterns https://charts.validatedpatterns.io
+      </code></pre>
+
+      <p>These is the list of charts used by the Validated Patterns project.
+      For more information consult the <a
+      href="https://validatedpatterns.io">Validated Patterns</a> website.
+
+      <h2>Charts</h2>
+
+      <ul>
+			{{range $key, $chartEntry := .Entries }}
+				<li>
+					<p>
+						{{ (index $chartEntry 0).Name }}
+						(<a href="{{ (index (index $chartEntry 0).Urls 0) }}" title="{{ (index (index $chartEntry 0).Urls 0) }}">
+						{{ (index $chartEntry 0).Version }}
+						@
+						{{ (index $chartEntry 0).AppVersion }}
+						</a>)
+					</p>
+					<p>
+						{{ (index $chartEntry 0).Description }}
+					</p>
+				</li>
+			{{end}}
+      </ul>
+    </section>
+		<time datetime="{{ .Generated.Format "2006-01-02T15:04:05" }}" pubdate id="generated">{{ .Generated.Format "Mon Jan 2 2006 03:04:05PM MST-07:00" }}</time>
+  </body>
+</html>


### PR DESCRIPTION
We generate index.html and then add it to the gh-pages branch.
The template for it lives in `index.tpl`
