### PR TITLE
Stop signing with subkey for the time being

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -232,19 +232,19 @@ jobs:
           echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
           echo "CHART_TGZ=${CHART_TGZ}" >> $GITHUB_ENV
 
-      - name: Sign the chart
-        shell: bash
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |-
-          set -euo pipefail
-          echo ${{ secrets.GPG_SECRET_SUBKEY }} | base64 -d | gpg --batch --import
-          echo ${{ secrets.GPG_PUBLIC_KEY }} | base64 -d | gpg --batch --import
-          # Needed because helm verify only supports old format
-          gpg --export >~/.gnupg/pubring.gpg
-          pip install git+https://gitlab.com/mbaldessari/helm-sign.git@couple-of-fixes
-          helm-sign ${{ env.CHART_TGZ }}
-          helm verify ${{ env.CHART_TGZ }}
+      # - name: Sign the chart
+      #   shell: bash
+      #   env:
+      #     GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      #   run: |-
+      #     set -euo pipefail
+      #     echo ${{ secrets.GPG_SECRET_SUBKEY }} | base64 -d | gpg --batch --import
+      #     echo ${{ secrets.GPG_PUBLIC_KEY }} | base64 -d | gpg --batch --import
+      #     # Needed because helm verify only supports old format
+      #     gpg --export >~/.gnupg/pubring.gpg
+      #     pip install git+https://gitlab.com/mbaldessari/helm-sign.git@couple-of-fixes
+      #     helm-sign ${{ env.CHART_TGZ }}
+      #     helm verify ${{ env.CHART_TGZ }}
 
       - name: Upload helm package as a release asset
         uses: svenstaro/upload-release-action@v2
@@ -256,15 +256,15 @@ jobs:
           body: "${{ env.CHART_NAME }} Released ${{ env.CHART_VERSION }}"
           overwrite: true
 
-      - name: Upload helm package signature as a release asset
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.CHART_TGZ }}.prov
-          asset_name: ${{ env.CHART_TGZ }}.prov
-          tag: ${{ github.ref }}
-          body: "${{ env.CHART_NAME }} Released ${{ env.CHART_VERSION }}"
-          overwrite: true
+      # - name: Upload helm package signature as a release asset
+      #   uses: svenstaro/upload-release-action@v2
+      #   with:
+      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #     file: ${{ env.CHART_TGZ }}.prov
+      #     asset_name: ${{ env.CHART_TGZ }}.prov
+      #     tag: ${{ github.ref }}
+      #     body: "${{ env.CHART_NAME }} Released ${{ env.CHART_VERSION }}"
+      #     overwrite: true
           # Uploaded to https://github.com/validatedpatterns/helm-charts/releases/download/main/test-0.0.1.tgz
 
       # This step fetches all assets and places them in the current folder


### PR DESCRIPTION
I'll look at this more in detail next week
We might decide to drop this entirely and just use containers by default and sign those.