### PR TITLE
mv instead of cp so that only one release tgz exists

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -67,7 +67,7 @@ jobs:
         run: |-
           set -euo pipefail
           cd helm-repo
-          
+
           # Determine the chart directory - check if TEMPLATE_DIR is provided or use default
           if [ -n "${TEMPLATE_DIR}" ]; then
             CHART_DIR="${TEMPLATE_DIR}"
@@ -84,22 +84,22 @@ jobs:
               exit 1
             fi
           fi
-          
+
           cd "${CHART_DIR}"
-          
+
           # Check if Chart.yaml exists and has dependencies
           if [ -f "Chart.yaml" ]; then
             echo "Found Chart.yaml in ${CHART_DIR}"
             cat Chart.yaml
-            
+
             # Check if dependencies section exists in Chart.yaml
             if yq -e '.dependencies' Chart.yaml > /dev/null 2>&1; then
               echo "Dependencies found in Chart.yaml. Processing dependencies..."
-              
+
               # Create a temporary file to track if repositories were added
               repo_added_flag=$(mktemp)
               echo "false" > "$repo_added_flag"
-              
+
               # Extract repository URLs from dependencies and add them as helm repositories
               echo "Discovering repositories from Chart.yaml dependencies..."
               yq -r '.dependencies[]? | select(.repository) | .repository' Chart.yaml | sort -u | while read -r repo_url; do
@@ -114,7 +114,7 @@ jobs:
                   fi
                 fi
               done
-              
+
               # Add additional helm repositories if specified
               if [ -n "${ADDITIONAL_HELM_REPOS}" ] && [ "${ADDITIONAL_HELM_REPOS}" != "[]" ] && [ "${ADDITIONAL_HELM_REPOS}" != "" ]; then
                 echo "Adding additional helm repositories..."
@@ -127,18 +127,18 @@ jobs:
                   fi
                 done
               fi
-              
+
               # Update repositories only if any were added
               repos_added=$(cat "$repo_added_flag")
               rm -f "$repo_added_flag"
-              
+
               if [ "$repos_added" = "true" ]; then
                 echo "Updating helm repositories..."
                 helm repo update
               else
                 echo "No repositories were added, skipping helm repo update"
               fi
-              
+
               # Check if dependencies are already present
               update_needed=false
               if [ -d "charts" ]; then
@@ -148,7 +148,7 @@ jobs:
                 if [ -n "$required_deps" ]; then
                   echo "Required dependencies:"
                   echo "$required_deps"
-                  
+
                   # Check each required dependency
                   for dep in $required_deps; do
                     dep_name=$(echo "$dep" | cut -d'-' -f1)
@@ -169,12 +169,12 @@ jobs:
                 echo "Charts directory does not exist, dependencies update needed"
                 update_needed=true
               fi
-              
+
               # Update dependencies only if needed
               if [ "$update_needed" = true ]; then
                 echo "Updating dependencies..."
                 helm dependency update
-                
+
                 # Verify dependencies were downloaded
                 if [ -d "charts" ]; then
                   echo "Dependencies successfully downloaded:"
@@ -202,7 +202,7 @@ jobs:
         run: |-
           set -euo pipefail
           cd helm-repo
-          
+
           # Determine the chart directory - same logic as dependency handling
           if [ -n "${TEMPLATE_DIR}" ]; then
             CHART_DIR="${TEMPLATE_DIR}"
@@ -219,15 +219,15 @@ jobs:
               exit 1
             fi
           fi
-          
+
           # Package the chart
           helm package "${CHART_DIR}"
           # Read chart metadata from the determined chart directory
           CHART_NAME=$(yq -r '.name' "${CHART_DIR}/Chart.yaml")
           CHART_VERSION=$(yq -r '.version' "${CHART_DIR}/Chart.yaml")
           CHART_TGZ="${CHART_NAME}-${CHART_VERSION}.tgz"
-          # Copy chart to parent dir because this variable is meant to only be the filename
-          cp ${CHART_TGZ} ..
+          # Move chart to parent dir
+          mv ${CHART_TGZ} ..
           echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
           echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
           echo "CHART_TGZ=${CHART_TGZ}" >> $GITHUB_ENV


### PR DESCRIPTION
What is happening now:

Let `WD` be the working directory

1. The *Package the helm chart* step creates the tgz for the helm release and then copies it from `$WD/helm-repo` to `$WD`.
2. In the *Upload helm package as a release asset* step, only the release tgz in `$WD` is published to the github release page
3. In the *Update the helm index.yaml file* step,  both tgzs are found by the `helm repo index --url "${ASSETS_BASE_URL}" .` command.
4. In the *Commit to gh-pages* step, the helm repo-html grabs the first entry for each chart it finds. This is why our charts.validatedpatterns.io only displays the latest version even though there are all the versions on the release page itself. Unfortunately for us, because of the copy of the tgz release, the first index in the index.yaml generated by `helm repo index` in the previous step is for the tgz file which was not published to the github releases page. Thus, the broken link is included in the index.html rather than the link to the tgz that was published.
