### PR TITLE
add secrets block to workflow

### DIFF
--- a/.github/workflows/update-helm-repo.yml
+++ b/.github/workflows/update-helm-repo.yml
@@ -16,6 +16,9 @@
 name: vp-patterns/update-helm-repo
 on:
   workflow_call:
+    secrets:
+      CHARTS_REPOS_TOKEN:
+        required: true
 
 jobs:
   update-umbrella-repo:


### PR DESCRIPTION
@mbaldessari This enables us to prpoerly pass the chart repo token secret:

```yaml
name: vp-patterns/update-helm-repo

on:
  push:
    tags:
      - "v[0-9]+.[0-9]+.[0-9]+"

permissions:
  contents: read

jobs:
  helmlint:
    uses: dminnear-rh/helm-charts/.github/workflows/helmlint.yml@29d4c96c70faf37d0cf8f48206e598ce45a7b77e # September 8, 2025
    permissions:
      contents: read

  update-helm-repo:
    needs: [helmlint]
    uses: dminnear-rh/helm-charts/.github/workflows/update-helm-repo.yml@29d4c96c70faf37d0cf8f48206e598ce45a7b77e # September 8, 2025
    permissions:
      contents: read
    secrets:
      CHARTS_REPOS_TOKEN: ${{ secrets.CHARTS_REPOS_TOKEN }}
```

I tested it with a new chart (llm-inference-service). We'll need to add this before we can update the workflow SHA in https://github.com/validatedpatterns/vp-template-chart/pull/4 and enable new charts to pass the zizmor linter