### PR TITLE
fix(ci): publish-charts Helm repo names and empty repo update

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -81,18 +81,32 @@ jobs:
             exit 0
           fi
 
-          yq -r '.dependencies[]? | select(.repository) | .repository' Chart.yaml \
-            | sort -u \
-            | while read -r repo_url; do
-                [[ "$repo_url" == http* ]] || continue
-                repo_name="${repo_url#https://}"
-                repo_name="${repo_name#http://}"
-                repo_name="${repo_name%/}"
-                echo "Adding repo: ${repo_name} -> ${repo_url}"
-                helm repo add "${repo_name}" "${repo_url}" || true
-              done
+          tmp="$(mktemp)"
+          yq -r '.dependencies[]? | select(.repository) | .repository' Chart.yaml >>"$tmp"
+          if [[ -f Chart.lock ]]; then
+            yq -r '.dependencies[]? | select(.repository) | .repository' Chart.lock >>"$tmp"
+          fi
 
-          helm repo update
+          sort -u "$tmp" | while read -r repo_url; do
+            if [[ "$repo_url" != http://* && "$repo_url" != https://* ]]; then
+              echo "Skipping non-HTTP repository reference: ${repo_url}"
+              continue
+            fi
+            # Helm repo *names* cannot contain '/'. URL-derived names like
+            # stakater.github.io/stakater-charts always fail helm repo add.
+            repo_safe="ext-$(printf '%s' "$repo_url" | sha256sum | awk '{print $1}' | cut -c1-16)"
+            echo "Adding repo: ${repo_safe} -> ${repo_url}"
+            helm repo add "${repo_safe}" "${repo_url}" --force-update
+          done
+          rm -f "$tmp"
+
+          repo_count="$(helm repo list -o json 2>/dev/null | jq 'length' 2>/dev/null || echo 0)"
+          if [ "${repo_count}" -gt 0 ]; then
+            helm repo update
+          else
+            echo "Skipping helm repo update: no HTTP chart repositories were registered"
+          fi
+
           helm dependency build
 
       - name: Package the helm chart


### PR DESCRIPTION
## Summary

- **Bug:** `publish-charts` derived Helm repo *names* from HTTP URLs by stripping the scheme, producing values like `stakater.github.io/stakater-charts`. Helm rejects `/` in repo names, so every `helm repo add` failed. Failures were hidden with `|| true`, then `helm repo update` ran with **zero** repos and failed with `no repositories found`.
- **Also:** Only `Chart.yaml` was scanned, so charts using `@alias` in `Chart.yaml` with resolved `https://…` URLs in `Chart.lock` never registered a repo.

## Changes

- Collect unique `repository` values from **Chart.yaml and Chart.lock**.
- Add repos with a stable slash-free name (`ext-` + first 16 hex chars of SHA256 of the URL) and **`--force-update`**, without `|| true`.
- Run **`helm repo update`** only when `helm repo list -o json` has at least one entry (`jq length`).

## Test plan

- [ ] Re-run `publish-charts` for a chart that depends on `https://stakater.github.io/stakater-charts` (or any `https://host/path` index).
- [ ] Confirm the "Build chart dependencies" step adds a repo, runs `helm repo update` when appropriate, and `helm dependency build` succeeds.

Made with [Cursor](https://cursor.com)