### PR TITLE
fix(ci): Helm alias repos and trust vendored chart dependencies

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,6 +29,25 @@ chart-repos:
 
 Direct `https://` repository URLs continue to work without `ct.yaml`. Git (`git:`), OCI (`oci://`), and `file://` dependencies are not registered via `helm repo add`; use vendored `charts/*.tgz`, HTTPS/OCI URLs, or extend CI separately for those cases.
 
+### Vendored `charts/*.tgz` (skip dependency build)
+
+When every dependency in `Chart.lock` has a matching `charts/<name>-<version>.tgz` in the tagged commit, `publish-charts` skips `helm repo add` and `helm dependency build` (no network fetch). Archives are validated with `helm show chart`.
+
+Control via `ct.yaml`:
+
+```yaml
+# Default when omitted: auto (skip build when vendored archives are complete)
+trust-vendored-charts: auto
+
+# Always require a fresh dependency build
+# trust-vendored-charts: false
+
+# Require vendored archives; fail publish if any are missing
+# trust-vendored-charts: true
+```
+
+Commit both `Chart.lock` and the vendored `.tgz` files on the release tag. `helm package` bundles whatever is in `charts/`.
+
 In order for the charts-repo github action to be able to invoke a workflow from
 the umbrella repository it needs a PAT token with the following permissions:
 - Actions: r/w

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,33 @@ There are two workflows here:
 1. update-helm-repo.yml which should be added to each charts' repository
 2. publish-charts.yml gets invoked by the 'update-helm-repo.yml' any time a new version tag is pushed to the charts repository
 
+### Helm repository aliases (`@name` / `alias:name`)
+
+Charts may declare HTTP chart repository dependencies using a Helm repo alias in `Chart.yaml`:
+
+```yaml
+dependencies:
+  - name: reloader
+    version: 2.2.11
+    repository: "@stakater"
+```
+
+`publish-charts` registers those aliases before `helm dependency build` by:
+
+1. Reading `chart-repos` from `ct.yaml` (same `name=https://url` format as [chart-testing](https://github.com/helm/chart-testing)), searched in the chart directory and repo root
+2. Falling back to the resolved HTTPS `repository` URL for the same dependency name in `Chart.lock`
+
+Example `ct.yaml` for a root-level chart:
+
+```yaml
+chart-dirs:
+  - .
+chart-repos:
+  - stakater=https://stakater.github.io/stakater-charts
+```
+
+Direct `https://` repository URLs continue to work without `ct.yaml`. Git (`git:`), OCI (`oci://`), and `file://` dependencies are not registered via `helm repo add`; use vendored `charts/*.tgz`, HTTPS/OCI URLs, or extend CI separately for those cases.
+
 In order for the charts-repo github action to be able to invoke a workflow from
 the umbrella repository it needs a PAT token with the following permissions:
 - Actions: r/w

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -74,39 +74,8 @@ jobs:
       - name: Build chart dependencies
         run: |-
           set -euo pipefail
+          bash scripts/register-chart-repos.sh "helm-repo/${CHART_DIR}"
           cd "helm-repo/${CHART_DIR}"
-
-          if ! yq -e '.dependencies' Chart.yaml > /dev/null 2>&1; then
-            echo "No dependencies declared in Chart.yaml"
-            exit 0
-          fi
-
-          tmp="$(mktemp)"
-          yq -r '.dependencies[]? | select(.repository) | .repository' Chart.yaml >>"$tmp"
-          if [[ -f Chart.lock ]]; then
-            yq -r '.dependencies[]? | select(.repository) | .repository' Chart.lock >>"$tmp"
-          fi
-
-          sort -u "$tmp" | while read -r repo_url; do
-            if [[ "$repo_url" != http://* && "$repo_url" != https://* ]]; then
-              echo "Skipping non-HTTP repository reference: ${repo_url}"
-              continue
-            fi
-            # Helm repo *names* cannot contain '/'. URL-derived names like
-            # stakater.github.io/stakater-charts always fail helm repo add.
-            repo_safe="ext-$(printf '%s' "$repo_url" | sha256sum | awk '{print $1}' | cut -c1-16)"
-            echo "Adding repo: ${repo_safe} -> ${repo_url}"
-            helm repo add "${repo_safe}" "${repo_url}" --force-update
-          done
-          rm -f "$tmp"
-
-          repo_count="$(helm repo list -o json 2>/dev/null | jq 'length' 2>/dev/null || echo 0)"
-          if [ "${repo_count}" -gt 0 ]; then
-            helm repo update
-          else
-            echo "Skipping helm repo update: no HTTP chart repositories were registered"
-          fi
-
           helm dependency build
 
       - name: Package the helm chart

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -35,6 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
+      - name: Checkout umbrella repo
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts
+          sparse-checkout-cone-mode: false
+
       - name: Install Helm
         uses: azure/setup-helm@v5.0.0
         with:
@@ -74,9 +81,7 @@ jobs:
       - name: Build chart dependencies
         run: |-
           set -euo pipefail
-          bash scripts/register-chart-repos.sh "helm-repo/${CHART_DIR}"
-          cd "helm-repo/${CHART_DIR}"
-          helm dependency build
+          bash scripts/prepare-chart-dependencies.sh "helm-repo/${CHART_DIR}"
 
       - name: Package the helm chart
         run: |-

--- a/scripts/prepare-chart-dependencies.sh
+++ b/scripts/prepare-chart-dependencies.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Register Helm repos (if needed) and build chart dependencies, or trust vendored charts/.
+set -euo pipefail
+
+chart_dir="${1:-.}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if "${script_dir}/should-trust-vendored-charts.sh" "${chart_dir}"; then
+  echo "Skipping helm repo registration and helm dependency build (vendored charts match Chart.lock)"
+  exit 0
+fi
+
+echo "Vendored charts incomplete or trust disabled; building dependencies from Chart.lock"
+"${script_dir}/register-chart-repos.sh" "${chart_dir}"
+cd "${chart_dir}"
+helm dependency build

--- a/scripts/register-chart-repos.sh
+++ b/scripts/register-chart-repos.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Register Helm chart repositories required by Chart.yaml / Chart.lock before
+# helm dependency build. Used by publish-charts CI and runnable locally.
+set -euo pipefail
+
+chart_dir="${1:-.}"
+cd "${chart_dir}"
+
+declare -A chart_repos=()
+
+load_ct_chart_repos() {
+  local ct_file=""
+  for candidate in ./ct.yaml ../ct.yaml; do
+    if [[ -f "${candidate}" ]] && yq -e '.["chart-repos"]' "${candidate}" >/dev/null 2>&1; then
+      ct_file="${candidate}"
+      break
+    fi
+  done
+  if [[ -z "${ct_file}" ]]; then
+    return 0
+  fi
+  echo "Loading chart-repos from ${ct_file}"
+  while IFS= read -r entry; do
+    [[ -z "${entry}" ]] && continue
+    local name="${entry%%=*}"
+    local url="${entry#*=}"
+    chart_repos["${name}"]="${url}"
+  done < <(yq -r '.["chart-repos"][]?' "${ct_file}")
+}
+
+resolve_alias_url() {
+  local dep_name="$1"
+  local alias="$2"
+  local url=""
+
+  if [[ -n "${chart_repos[${alias}]+x}" ]]; then
+    echo "${chart_repos[${alias}]}"
+    return 0
+  fi
+
+  if [[ -f Chart.lock ]]; then
+    url="$(yq -r ".dependencies[] | select(.name == \"${dep_name}\") | .repository" Chart.lock | head -n1)"
+    if [[ "${url}" == http://* || "${url}" == https://* ]]; then
+      echo "${url}"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+helm_repo_safe_name() {
+  printf '%s' "$1" | sha256sum | awk '{print $1}' | cut -c1-16 | awk '{print "ext-" $1}'
+}
+
+register_http_repo() {
+  local repo_url="$1"
+  local repo_name
+  repo_name="$(helm_repo_safe_name "${repo_url}")"
+  echo "Adding repo: ${repo_name} -> ${repo_url}"
+  helm repo add "${repo_name}" "${repo_url}" --force-update
+}
+
+register_alias_repo() {
+  local alias="$1"
+  local repo_url="$2"
+  echo "Adding repo: ${alias} -> ${repo_url}"
+  helm repo add "${alias}" "${repo_url}" --force-update
+}
+
+normalize_alias() {
+  local repo_ref="$1"
+  if [[ "${repo_ref}" == @* ]]; then
+    echo "${repo_ref#@}"
+    return 0
+  fi
+  if [[ "${repo_ref}" == alias:* ]]; then
+    echo "${repo_ref#alias:}"
+    return 0
+  fi
+  return 1
+}
+
+main() {
+  if ! yq -e '.dependencies' Chart.yaml >/dev/null 2>&1; then
+    echo "No dependencies declared in Chart.yaml"
+    exit 0
+  fi
+
+  load_ct_chart_repos
+
+  while IFS=$'\t' read -r dep_name repo_ref; do
+    [[ -z "${repo_ref}" ]] && continue
+    local alias=""
+    if alias="$(normalize_alias "${repo_ref}")"; then
+      local url=""
+      if ! url="$(resolve_alias_url "${dep_name}" "${alias}")"; then
+        echo "::error::Cannot resolve Helm repository alias \"${alias}\" for dependency \"${dep_name}\". Define it in ct.yaml chart-repos (name=url), commit a Chart.lock with an HTTPS repository URL, or use an HTTPS repository URL in Chart.yaml."
+        exit 1
+      fi
+      register_alias_repo "${alias}" "${url}"
+    fi
+  done < <(yq -r '.dependencies[]? | select(.repository) | [.name, .repository] | @tsv' Chart.yaml)
+
+  local tmp
+  tmp="$(mktemp)"
+  yq -r '.dependencies[]? | select(.repository) | .repository' Chart.yaml >>"${tmp}"
+  if [[ -f Chart.lock ]]; then
+    yq -r '.dependencies[]? | select(.repository) | .repository' Chart.lock >>"${tmp}"
+  fi
+
+  sort -u "${tmp}" | while read -r repo_url; do
+    [[ -z "${repo_url}" ]] && continue
+    if [[ "${repo_url}" == @* || "${repo_url}" == alias:* ]]; then
+      continue
+    fi
+    if [[ "${repo_url}" == http://* || "${repo_url}" == https://* ]]; then
+      register_http_repo "${repo_url}"
+      continue
+    fi
+    if [[ "${repo_url}" == oci://* ]]; then
+      echo "Skipping OCI repository (use helm registry login in CI if needed): ${repo_url}"
+      continue
+    fi
+    if [[ "${repo_url}" == file://* ]]; then
+      echo "Skipping file repository (local path): ${repo_url}"
+      continue
+    fi
+    echo "Skipping unsupported repository reference: ${repo_url}"
+  done
+  rm -f "${tmp}"
+
+  local repo_count
+  repo_count="$(helm repo list -o json 2>/dev/null | jq 'length' 2>/dev/null || echo 0)"
+  if [[ "${repo_count}" -gt 0 ]]; then
+    helm repo update
+  else
+    echo "Skipping helm repo update: no HTTP chart repositories were registered"
+  fi
+}
+
+main "$@"

--- a/scripts/should-trust-vendored-charts.sh
+++ b/scripts/should-trust-vendored-charts.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Exit 0 when committed charts/*.tgz match Chart.lock and dependency build can be skipped.
+# Exit 1 when helm dependency build (and repo registration) should run.
+set -euo pipefail
+
+chart_dir="${1:-.}"
+cd "${chart_dir}"
+
+ct_trust_vendored() {
+  local ct_file=""
+  for candidate in ./ct.yaml ../ct.yaml; do
+    if [[ -f "${candidate}" ]]; then
+      ct_file="${candidate}"
+      break
+    fi
+  done
+  if [[ -z "${ct_file}" ]]; then
+    echo "auto"
+    return 0
+  fi
+  if yq -e '.["trust-vendored-charts"]' "${ct_file}" >/dev/null 2>&1; then
+    yq -r '.["trust-vendored-charts"]' "${ct_file}"
+    return 0
+  fi
+  echo "auto"
+}
+
+if ! yq -e '.dependencies' Chart.yaml >/dev/null 2>&1; then
+  echo "No dependencies in Chart.yaml"
+  exit 0
+fi
+
+trust_mode="$(ct_trust_vendored)"
+case "${trust_mode}" in
+  false | "false")
+    echo "trust-vendored-charts is false in ct.yaml; will run helm dependency build"
+    exit 1
+    ;;
+  true | "true")
+    echo "trust-vendored-charts is true in ct.yaml"
+    ;;
+  auto | "auto")
+    ;;
+  *)
+    echo "::warning::Unknown trust-vendored-charts value \"${trust_mode}\"; using auto"
+    ;;
+esac
+
+if [[ ! -f Chart.lock ]]; then
+  echo "Chart.lock is missing; cannot trust vendored charts"
+  exit 1
+fi
+
+missing=0
+while IFS=$'\t' read -r dep_name dep_version; do
+  [[ -z "${dep_name}" ]] && continue
+  chart_tgz="charts/${dep_name}-${dep_version}.tgz"
+  if [[ ! -f "${chart_tgz}" ]]; then
+    echo "Missing vendored chart archive: ${chart_tgz}"
+    missing=1
+    continue
+  fi
+  if [[ ! -s "${chart_tgz}" ]]; then
+    echo "Vendored chart archive is empty: ${chart_tgz}"
+    missing=1
+    continue
+  fi
+  if ! helm show chart "${chart_tgz}" >/dev/null 2>&1; then
+    echo "Vendored chart archive is not a valid Helm package: ${chart_tgz}"
+    missing=1
+  fi
+done < <(yq -r '.dependencies[] | [.name, .version] | @tsv' Chart.lock)
+
+if [[ "${missing}" -ne 0 ]]; then
+  exit 1
+fi
+
+lock_count="$(yq -r '.dependencies | length' Chart.lock)"
+yaml_count="$(yq -r '.dependencies | length' Chart.yaml)"
+if [[ "${lock_count}" != "${yaml_count}" ]]; then
+  echo "Chart.yaml declares ${yaml_count} dependencies but Chart.lock has ${lock_count}"
+  exit 1
+fi
+
+while IFS=$'\t' read -r dep_name dep_version; do
+  [[ -z "${dep_name}" ]] && continue
+  lock_version="$(yq -r ".dependencies[] | select(.name == \"${dep_name}\") | .version" Chart.lock | head -n1)"
+  if [[ "${lock_version}" != "${dep_version}" ]]; then
+    echo "Chart.yaml version for ${dep_name} (${dep_version}) does not match Chart.lock (${lock_version})"
+    exit 1
+  fi
+done < <(yq -r '.dependencies[] | [.name, .version] | @tsv' Chart.yaml)
+
+echo "All ${lock_count} Chart.lock dependencies are present as vendored charts/*.tgz"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/prepare-chart-dependencies.sh` for the `publish-charts` dependency step
- Resolves `@name` / `alias:name` dependencies by registering `helm repo add <alias> <url>` (required by Helm; `ext-*` hashed names do not satisfy aliases)
- Reads alias mappings from `ct.yaml` `chart-repos` (chart-testing format) and falls back to the matching dependency HTTPS URL in `Chart.lock`
- Keeps PR #32 behavior for direct `https://` repository URLs (`ext-*` safe names)
- Skips `helm repo add` and `helm dependency build` when committed `charts/<name>-<version>.tgz` archives match `Chart.lock` (no network fetch)
- Checks out umbrella `scripts/` before cloning the chart source repo

## Motivation

Charts such as `vp-stakater-reloader` use `repository: "@stakater"` for readability and `ct lint` compatibility. After #32, `publish-charts` logged `Skipping non-HTTP repository reference: @stakater`, registered only the lock-file URL under `ext-*`, and `helm dependency build` failed with `no repository definition for @stakater`.

Charts that vendor `charts/*.tgz` for offline CI still had `publish-charts` re-download dependencies on every tag push. Committed archives matching `Chart.lock` can now be trusted instead.

## Vendored charts (`trust-vendored-charts`)

When every `Chart.lock` dependency has a valid `charts/<name>-<version>.tgz` on the tagged commit, publish skips dependency resolution entirely. This also works with `@alias` in `Chart.yaml` because Helm never needs to resolve the alias at publish time.

`ct.yaml` options:

```yaml
trust-vendored-charts: auto   # default: skip when archives are complete
# trust-vendored-charts: false  # always run helm dependency build
# trust-vendored-charts: true    # require vendored archives; fail if missing
```

## Test plan

- [ ] Run `scripts/register-chart-repos.sh` against a chart with `repository: "@stakater"` and `ct.yaml` `chart-repos`
- [ ] Repeat without `ct.yaml` but with HTTPS URL in `Chart.lock` for the same dependency name
- [ ] Run `scripts/should-trust-vendored-charts.sh` on a chart with `Chart.lock` + vendored `charts/*.tgz`; expect exit 0
- [ ] Run `scripts/prepare-chart-dependencies.sh` on the same chart; confirm it skips build without network
- [ ] Remove a vendored `.tgz`; confirm `prepare-chart-dependencies.sh` falls back to `helm dependency build`
- [ ] Dispatch `publish-charts` for a tagged chart using `@alias` dependencies
- [ ] Dispatch `publish-charts` for a tagged chart with vendored dependencies only
- [ ] Confirm charts using only `https://` repository URLs still publish successfully when vendored archives are absent

## Notes

- Git (`git:`), OCI, and `file://` dependencies are intentionally out of scope for `helm repo add`; use vendored `charts/*.tgz`, HTTPS/OCI URLs, or extend CI separately for those cases.